### PR TITLE
[codex] chore: consolidate dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      gradle-dependencies:
+        patterns:
+          - "*"
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "com.velocitypowered:velocity-api"
@@ -13,3 +17,7 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,23 +10,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build with Gradle
         run: ./gradlew build
 
       - name: Upload build reports
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-reports
           path: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,26 +24,26 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build
         run: ./gradlew compileJava
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -17,16 +17,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Generate Javadoc
         run: ./gradlew javadoc
@@ -55,7 +55,7 @@ jobs:
           EOF
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
@@ -68,4 +68,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,22 +9,22 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build
         run: ./gradlew build
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,7 +75,7 @@ subprojects {
 
     val pitestConfiguration = configurations.maybeCreate("pitest")
     dependencies.add("pitest", "org.pitest:pitest-command-line:${rootProject.libs.versions.pitest.get()}")
-    dependencies.add("pitest", "org.pitest:pitest-junit5-plugin:1.2.1")
+    dependencies.add("pitest", "org.pitest:pitest-junit5-plugin:1.2.3")
 
     tasks.register<JavaExec>("pitest") {
         group = "verification"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,15 @@
 [versions]
-bucket4j = "8.14.0"
-caffeine = "3.1.8"
+bucket4j = "8.18.0"
+caffeine = "3.2.3"
 jmh = "1.37"
-junit = "5.11.4"
+junit = "6.0.3"
 jspecify = "1.0.0"
-paper = "1.21.4-R0.1-SNAPSHOT"
-pitest = "1.17.3"
-shadow = "9.3.2"
+paper = "1.21.11-R0.1-SNAPSHOT"
+pitest = "1.23.1"
+shadow = "9.4.1"
 sonarqube = "7.2.3.7755"
 spotless = "8.4.0"
-velocity = "3.4.0-SNAPSHOT"
+velocity = "3.5.0-SNAPSHOT"
 
 [libraries]
 bucket4j-core = { module = "com.bucket4j:bucket4j_jdk17-core", version.ref = "bucket4j" }
@@ -26,7 +26,7 @@ velocity-api = { module = "com.velocitypowered:velocity-api", version.ref = "vel
 
 [plugins]
 jmh = { id = "me.champeau.jmh", version = "0.7.3" }
-pitest = { id = "info.solidsoft.pitest", version = "1.15.2" }
+pitest = { id = "info.solidsoft.pitest", version = "1.19.0" }
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
## What changed

- Consolidates the open Dependabot dependency updates into one branch.
- Updates Gradle dependency versions from the current Dependabot PRs.
- Updates GitHub Actions across all workflows, including `javadoc.yml` and `codeql.yml`, which were not covered by the open Dependabot PRs.
- Adds Dependabot groups for Gradle and GitHub Actions updates so future updates arrive in fewer PRs.

## Supersedes

This PR supersedes Dependabot PRs #1 through #15.

## Validation

- `./gradlew spotlessApply`
- `git diff --check`
- `./gradlew build`