### PR TITLE
[codex] fix: harden command registration edge cases

### DIFF
--- a/command-annotations/src/main/java/io/github/hanielcota/commandframework/annotation/platform/PlatformCommandAdapter.java
+++ b/command-annotations/src/main/java/io/github/hanielcota/commandframework/annotation/platform/PlatformCommandAdapter.java
@@ -4,7 +4,9 @@ import io.github.hanielcota.commandframework.annotation.scan.AnnotatedCommandSca
 import io.github.hanielcota.commandframework.core.CommandDispatcher;
 import io.github.hanielcota.commandframework.core.CommandRoot;
 import io.github.hanielcota.commandframework.core.CommandRoute;
+import io.github.hanielcota.commandframework.core.route.CommandLiteralNormalizer;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -17,7 +19,8 @@ public abstract class PlatformCommandAdapter {
 
     private final CommandDispatcher dispatcher;
     private final AnnotatedCommandScanner scanner;
-    private final Set<CommandRoot> registeredRoots = ConcurrentHashMap.newKeySet();
+    private final CommandLiteralNormalizer normalizer = new CommandLiteralNormalizer();
+    private final Map<String, CommandRoot> registeredRoots = new ConcurrentHashMap<>();
     private final List<CommandRoute> registeredRoutes = new CopyOnWriteArrayList<>();
 
     protected PlatformCommandAdapter(CommandDispatcher dispatcher, AnnotatedCommandScanner scanner) {
@@ -48,14 +51,22 @@ public abstract class PlatformCommandAdapter {
 
     private void registerPlatformRoots() {
         for (CommandRoot root : dispatcher.roots()) {
-            if (!registeredRoots.contains(root)) {
-                try {
-                    registerRoot(root);
-                    registeredRoots.add(root);
-                } catch (RuntimeException exception) {
-                    dispatcher.logger().warn("Failed to register command root: " + root.label(), exception);
-                }
+            String label = normalizer.normalize(root.label());
+            CommandRoot previous = registeredRoots.putIfAbsent(label, root);
+            if (previous == null) {
+                registerPlatformRoot(label, root);
+            } else if (!previous.equals(root)) {
+                registeredRoots.replace(label, previous, root);
             }
+        }
+    }
+
+    private void registerPlatformRoot(String label, CommandRoot root) {
+        try {
+            registerRoot(root);
+        } catch (RuntimeException exception) {
+            registeredRoots.remove(label, root);
+            dispatcher.logger().warn("Failed to register command root: " + root.label(), exception);
         }
     }
 
@@ -64,7 +75,7 @@ public abstract class PlatformCommandAdapter {
             dispatcher.unregister(route);
         }
         registeredRoutes.clear();
-        for (CommandRoot root : registeredRoots) {
+        for (CommandRoot root : registeredRoots.values()) {
             unregisterRoot(root);
         }
         registeredRoots.clear();
@@ -79,6 +90,6 @@ public abstract class PlatformCommandAdapter {
     protected abstract void unregisterRoot(CommandRoot root);
 
     protected Set<CommandRoot> registeredRoots() {
-        return registeredRoots;
+        return Set.copyOf(registeredRoots.values());
     }
 }

--- a/command-annotations/src/test/java/io/github/hanielcota/commandframework/annotation/platform/PlatformCommandAdapterTest.java
+++ b/command-annotations/src/test/java/io/github/hanielcota/commandframework/annotation/platform/PlatformCommandAdapterTest.java
@@ -1,0 +1,57 @@
+package io.github.hanielcota.commandframework.annotation.platform;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.github.hanielcota.commandframework.annotation.scan.AnnotatedCommandScanner;
+import io.github.hanielcota.commandframework.core.CommandDispatcher;
+import io.github.hanielcota.commandframework.core.CommandResult;
+import io.github.hanielcota.commandframework.core.CommandRoot;
+import io.github.hanielcota.commandframework.core.CommandRoute;
+import io.github.hanielcota.commandframework.core.ParameterResolverRegistry;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class PlatformCommandAdapterTest {
+
+    @Test
+    void registersPlatformRootOnlyOnceWhenAliasesChange() {
+        CommandDispatcher dispatcher = CommandDispatcher.builder().build();
+        RecordingAdapter adapter = new RecordingAdapter(dispatcher);
+
+        adapter.registerRoutes(List.of(route("kit", Set.of("kits"), List.of("give"))));
+        adapter.registerRoutes(List.of(route("kit", Set.of("loadout"), List.of("take"))));
+
+        assertEquals(List.of("kit"), adapter.registeredLabels());
+    }
+
+    private CommandRoute route(String root, Set<String> aliases, List<String> path) {
+        return CommandRoute.builder(root, (context, parameters) -> CommandResult.success())
+                .aliases(aliases)
+                .path(path)
+                .build();
+    }
+
+    private static final class RecordingAdapter extends PlatformCommandAdapter {
+
+        private final List<String> registeredLabels = new ArrayList<>();
+
+        private RecordingAdapter(CommandDispatcher dispatcher) {
+            super(dispatcher, new AnnotatedCommandScanner(ParameterResolverRegistry.withDefaults()));
+        }
+
+        List<String> registeredLabels() {
+            return registeredLabels;
+        }
+
+        @Override
+        protected void registerRoot(CommandRoot root) {
+            registeredLabels.add(root.label());
+        }
+
+        @Override
+        protected void unregisterRoot(CommandRoot root) {
+        }
+    }
+}

--- a/command-core/src/main/java/io/github/hanielcota/commandframework/core/CommandRouteRegistry.java
+++ b/command-core/src/main/java/io/github/hanielcota/commandframework/core/CommandRouteRegistry.java
@@ -23,7 +23,7 @@ public final class CommandRouteRegistry implements RouteResolver {
     public synchronized void register(CommandRoute route) {
         CommandRoute checkedRoute = Objects.requireNonNull(route, "route");
         String normalizedRoot = normalizer.normalize(checkedRoute.root());
-        CommandRoot root = roots.computeIfAbsent(normalizedRoot, key -> createRoot(checkedRoute));
+        CommandRoot root = rootFor(checkedRoute, normalizedRoot);
         validateAliases(checkedRoute, root);
         CommandNode node = registerPath(checkedRoute, root.node());
         registerAliases(checkedRoute, root, normalizedRoot);
@@ -145,9 +145,26 @@ public final class CommandRouteRegistry implements RouteResolver {
         return Optional.ofNullable(aliasToRoot.get(normalizer.normalize(checkedLabel)));
     }
 
+    private CommandRoot rootFor(CommandRoute route, String normalizedRoot) {
+        CommandRoot existingRoot = roots.get(normalizedRoot);
+        if (existingRoot != null) {
+            return existingRoot;
+        }
+        CommandRoot existingAliasTarget = aliasToRoot.get(normalizedRoot);
+        if (existingAliasTarget != null) {
+            throw new RouteConfigurationException(
+                    "Invalid root '" + route.root() + "' for route '" + route.canonicalPath()
+                            + "': expected unused root label"
+            );
+        }
+        CommandRoot root = createRoot(route);
+        roots.put(normalizedRoot, root);
+        return root;
+    }
+
     private CommandRoot createRoot(CommandRoute route) {
         CommandRoot root = new CommandRoot(route.root(), Set.of(), new CommandNode(route.root()));
-        aliasToRoot.putIfAbsent(normalizer.normalize(route.root()), root);
+        aliasToRoot.put(normalizer.normalize(route.root()), root);
         return root;
     }
 

--- a/command-core/src/test/java/io/github/hanielcota/commandframework/core/route/CommandRouteRegistryTest.java
+++ b/command-core/src/test/java/io/github/hanielcota/commandframework/core/route/CommandRouteRegistryTest.java
@@ -58,6 +58,21 @@ final class CommandRouteRegistryTest {
     }
 
     @Test
+    void rejectsRootThatCollidesWithExistingAlias() {
+        CommandRouteRegistry registry = new CommandRouteRegistry();
+        registry.register(route("kit", Set.of("loadout"), List.of()));
+
+        assertThrows(
+                RouteConfigurationException.class,
+                () -> registry.register(route("loadout", Set.of(), List.of()))
+        );
+
+        RouteResolution resolution = registry.resolve("loadout", List.of());
+        assertTrue(resolution.isFound());
+        assertEquals("kit", resolution.match().orElseThrow().route().canonicalPath());
+    }
+
+    @Test
     void doesNotKeepAliasesFromRejectedDuplicateRoute() {
         CommandRouteRegistry registry = new CommandRouteRegistry();
         registry.register(route("kit", Set.of(), List.of("give")));

--- a/command-velocity/build.gradle.kts
+++ b/command-velocity/build.gradle.kts
@@ -3,4 +3,9 @@ dependencies {
     api(project(":command-annotations"))
     compileOnly(libs.velocity.api)
     implementation(libs.caffeine)
+
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.velocity.api)
+    testRuntimeOnly(libs.junit.platform.launcher)
 }

--- a/command-velocity/src/main/java/io/github/hanielcota/commandframework/velocity/VelocityRawCommandBridge.java
+++ b/command-velocity/src/main/java/io/github/hanielcota/commandframework/velocity/VelocityRawCommandBridge.java
@@ -25,9 +25,7 @@ final class VelocityRawCommandBridge implements RawCommand {
         dispatcher.dispatch(
                 actorFor(invocation.source()),
                 invocation.alias(),
-                invocation.arguments().isBlank()
-                        ? List.of()
-                        : List.of(invocation.arguments().split("\\s+")));
+                tokenize(invocation.arguments()));
     }
 
     @Override
@@ -35,9 +33,15 @@ final class VelocityRawCommandBridge implements RawCommand {
         return dispatcher.suggest(
                 actorFor(invocation.source()),
                 invocation.alias(),
-                invocation.arguments().isBlank()
-                        ? List.of()
-                        : List.of(invocation.arguments().split("\\s+")));
+                tokenize(invocation.arguments()));
+    }
+
+    static List<String> tokenize(String arguments) {
+        String normalized = Objects.requireNonNull(arguments, "arguments").trim();
+        if (normalized.isBlank()) {
+            return List.of();
+        }
+        return List.of(normalized.split("\\s+"));
     }
 
     private VelocityCommandActor actorFor(CommandSource source) {

--- a/command-velocity/src/test/java/io/github/hanielcota/commandframework/velocity/VelocityRawCommandBridgeTest.java
+++ b/command-velocity/src/test/java/io/github/hanielcota/commandframework/velocity/VelocityRawCommandBridgeTest.java
@@ -1,0 +1,19 @@
+package io.github.hanielcota.commandframework.velocity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+final class VelocityRawCommandBridgeTest {
+
+    @Test
+    void tokenizesBlankRawArgumentsAsEmptyList() {
+        assertEquals(List.of(), VelocityRawCommandBridge.tokenize("   "));
+    }
+
+    @Test
+    void trimsAndCollapsesWhitespaceWhenTokenizingRawArguments() {
+        assertEquals(List.of("give", "Steve", "daily"), VelocityRawCommandBridge.tokenize("  give   Steve daily  "));
+    }
+}


### PR DESCRIPTION
## What changed

- Rejects new root command labels that collide with aliases already registered for another root.
- Tracks platform-registered roots by normalized label so alias updates do not re-register the same root command.
- Normalizes Velocity raw command arguments with `trim()` before tokenizing, avoiding empty leading tokens from extra spaces.
- Adds regression tests for the registry, platform adapter registration, and Velocity raw tokenization.

## Validation

- `./gradlew :command-core:test :command-annotations:test :command-velocity:test`
- `./gradlew spotlessApply`
- `git diff --check`
- `./gradlew build`