### PR TITLE
[codex] docs: prepare v0.3.1 release

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,29 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+
+jobs:
+  enable-auto-merge:
+    if: github.actor == 'dependabot[bot]' && !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: contains(fromJSON('["version-update:semver-patch", "version-update:semver-minor"]'), steps.metadata.outputs.update-type)
+        run: gh pr merge "$PR_URL" --auto --merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Changelog
+
+All notable changes to CommandFramework are documented in this file.
+
+The project follows Git tag releases such as `v0.3.1`. JitPack consumers should
+use those tags as dependency versions.
+
+## [0.3.1] - 2026-04-22
+
+### Added
+
+- Added `llms.txt`, a compact usage and repository guide for LLMs, AI agents,
+  and documentation tools.
+- Added README badges for Build, CodeQL, Javadoc, and JitPack.
+- Added regression tests for route alias/root conflicts, platform root
+  registration, and Velocity raw argument tokenization.
+- Added a Dependabot auto-merge workflow for safe patch and minor dependency
+  updates.
+
+### Changed
+
+- Updated the root Gradle version to `0.3.1` so release artifacts match the Git
+  tag.
+- Updated README installation snippets to use `v0.3.1`.
+- Updated README requirements to Paper API `1.21.11+` and Velocity API
+  `3.5.0-SNAPSHOT+`.
+- Consolidated Dependabot dependency updates and grouped future Gradle/GitHub
+  Actions updates.
+- Updated GitHub Actions and CodeQL workflow versions.
+- Made CodeQL compile Java with `--rerun-tasks --no-build-cache` so analysis
+  still sees source compilation when Gradle caches are warm.
+
+### Fixed
+
+- Rejected root command labels that collide with an alias already registered for
+  another root.
+- Prevented platform adapters from re-registering the same root command when
+  aliases change after later route registrations.
+- Trimmed Velocity raw command input before tokenization to avoid empty leading
+  arguments.
+
+## [0.3.0] - 2026-04-22
+
+### Changed
+
+- Reworked the framework around the current dispatch pipeline architecture.
+- Added production-focused safety features, command registration polish, and
+  GitHub repository automation.
+
+[0.3.1]: https://github.com/HanielCota/CommandFramework/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/HanielCota/CommandFramework/releases/tag/v0.3.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # CommandFramework
 
+[![Build](https://github.com/HanielCota/CommandFramework/actions/workflows/build.yml/badge.svg)](https://github.com/HanielCota/CommandFramework/actions/workflows/build.yml)
+[![CodeQL](https://github.com/HanielCota/CommandFramework/actions/workflows/codeql.yml/badge.svg)](https://github.com/HanielCota/CommandFramework/actions/workflows/codeql.yml)
+[![Javadoc](https://github.com/HanielCota/CommandFramework/actions/workflows/javadoc.yml/badge.svg)](https://github.com/HanielCota/CommandFramework/actions/workflows/javadoc.yml)
+[![JitPack](https://jitpack.io/v/HanielCota/CommandFramework.svg)](https://jitpack.io/#HanielCota/CommandFramework)
+
 A lightweight, type-safe command framework for Minecraft server plugins, supporting both **Paper** (Bukkit) and **Velocity** proxy platforms.
 
 ## Features
@@ -26,8 +31,6 @@ A lightweight, type-safe command framework for Minecraft server plugins, support
 
 ## Installation (JitPack)
 
-[![](https://jitpack.io/v/HanielCota/CommandFramework.svg)](https://jitpack.io/#HanielCota/CommandFramework)
-
 Add the JitPack repository to your `build.gradle.kts`:
 
 ```kotlin
@@ -43,24 +46,24 @@ Add the dependencies you need:
 ```kotlin
 dependencies {
     // Paper plugin
-    implementation("com.github.HanielCota.CommandFramework:command-paper:main-SNAPSHOT")
+    implementation("com.github.HanielCota.CommandFramework:command-paper:v0.3.1")
     
     // Velocity plugin
-    implementation("com.github.HanielCota.CommandFramework:command-velocity:main-SNAPSHOT")
+    implementation("com.github.HanielCota.CommandFramework:command-velocity:v0.3.1")
     
     // Or individual modules
-    implementation("com.github.HanielCota.CommandFramework:command-core:main-SNAPSHOT")
-    implementation("com.github.HanielCota.CommandFramework:command-annotations:main-SNAPSHOT")
+    implementation("com.github.HanielCota.CommandFramework:command-core:v0.3.1")
+    implementation("com.github.HanielCota.CommandFramework:command-annotations:v0.3.1")
 }
 ```
 
-For a specific release, replace `main-SNAPSHOT` with a tag (e.g. `v1.0.0`).
+For snapshots from `main`, replace `v0.3.1` with `main-SNAPSHOT`.
 
 ## Requirements
 
 - **Java**: 21+
-- **Paper API**: 1.21.4+
-- **Velocity API**: 3.4.0+
+- **Paper API**: 1.21.11+
+- **Velocity API**: 3.5.0-SNAPSHOT+
 
 ## Quick Start
 
@@ -124,6 +127,12 @@ public class MyVelocityPlugin {
 ```bash
 ./gradlew build
 ```
+
+## Documentation
+
+- [LLM usage guide](llms.txt)
+- [Changelog](CHANGELOG.md)
+- [Javadoc](https://hanielcota.github.io/CommandFramework/)
 
 ## License
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "io.github.hanielcota.commandframework"
-version = "0.1.0-SNAPSHOT"
+version = "0.3.1"
 
 val platformProjects = setOf("command-paper", "command-velocity")
 

--- a/llms.txt
+++ b/llms.txt
@@ -60,6 +60,7 @@ annotated Java methods. It handles:
 ## Important Files
 
 - `README.md`: human-facing overview, installation, and quick start.
+- `CHANGELOG.md`: release history and user-facing changes.
 - `build.gradle.kts`: shared build configuration and publishing setup.
 - `settings.gradle.kts`: Gradle modules and plugin repositories.
 - `gradle/libs.versions.toml`: dependency and plugin versions.
@@ -108,7 +109,7 @@ dependencies {
 ```
 
 For snapshots from the main branch, use `main-SNAPSHOT`.
-For releases, use a Git tag such as `v0.3.0`.
+For releases, use a Git tag such as `v0.3.1`.
 
 ## Basic Paper Usage
 


### PR DESCRIPTION
## What changed

- Adds README badges for Build, CodeQL, Javadoc, and JitPack.
- Updates README installation snippets and requirements for v0.3.1.
- Adds CHANGELOG.md with v0.3.1 release notes.
- Updates the Gradle project version to 0.3.1 so release artifacts match the tag.
- Updates llms.txt with the changelog reference and current release tag.
- Adds a Dependabot auto-merge workflow for safe patch/minor updates.

## Validation

- ./gradlew spotlessApply
- git diff --check
- ./gradlew build