### PR TITLE
[codex] ci: allow release workflow to publish releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What changed

- Grants `contents: write` to the Release workflow so `softprops/action-gh-release` can create GitHub releases and generate release notes.

## Why

The first v0.3.1 tag run built successfully but failed at `Create Release` with `Resource not accessible by integration`.

## Validation

- git diff --check
- ./gradlew build